### PR TITLE
fix: pnpm install에서 --frozen-lockfile 옵션 제거

### DIFF
--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -3,8 +3,6 @@ name: Deploy Frontend to EC2
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   deploy:
@@ -38,7 +36,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install
 
       - name: Build application
         run: pnpm build

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,7 +23,7 @@ fi
 
 # 의존성 설치
 echo "의존성 설치 중..."
-pnpm install --frozen-lockfile --prod
+pnpm install --prod
 
 # 환경 변수 설정
 if [ -f .env.production ]; then


### PR DESCRIPTION
- GitHub Actions에서 pnpm-lock.yaml 인식 문제 해결
- pnpm install --frozen-lockfile → pnpm install로 변경
- 배포 스크립트에서도 동일하게 수정