### PR TITLE
fix: GitHub Actions에서 .env.production 파일 복사 제거

### DIFF
--- a/.github/workflows/deploy-front.yml
+++ b/.github/workflows/deploy-front.yml
@@ -64,7 +64,6 @@ jobs:
           scp package.json ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/var/www/salle-malle-front/
           scp pnpm-lock.yaml ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/var/www/salle-malle-front/
           scp next.config.mjs ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/var/www/salle-malle-front/
-          scp .env.production ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/var/www/salle-malle-front/
 
           # Copy deployment script
           scp deploy.sh ${{ secrets.EC2_USER }}@${{ secrets.EC2_HOST }}:/var/www/salle-malle-front/


### PR DESCRIPTION
- 보안상 GitHub에 올릴 수 없는 .env.production 파일 복사 부분 제거
- EC2에는 이미 .env.production 파일이 있으므로 문제없음