### PR TITLE
feat: 캘린더 페이지 API 연동 및 UI 개선

### DIFF
--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { TopNavigation } from "@/src/components/top-navigation";
 import { BottomNavigation } from "@/src/components/bottom-navigation";
 import {
@@ -11,19 +11,69 @@ import {
 } from "@/src/components/ui/card";
 import { Button } from "@/src/components/ui/button";
 import { Calendar, ChevronLeft, ChevronRight } from "lucide-react";
-
-const scheduleData = {
-  "2024-01-15": [
-    { time: "09:00", event: "삼성전자 3분기 실적 발표" },
-    { time: "14:00", event: "SK하이닉스 컨퍼런스 콜" },
-  ],
-  "2024-01-20": [{ time: "10:00", event: "NAVER 주주총회" }],
-  "2024-01-25": [{ time: "전일", event: "배당금 지급일" }],
-};
+import { EarningCall, EarningCallResponse } from "@/src/types/ApiResponse";
 
 export default function CalendarPage() {
-  const [selectedDate, setSelectedDate] = useState("2024-01-15");
-  const [currentMonth, setCurrentMonth] = useState(new Date(2024, 0, 1));
+  const today = new Date();
+  const todayString = today.toISOString().split("T")[0]; // YYYY-MM-DD 형식
+
+  const [selectedDate, setSelectedDate] = useState(todayString);
+  const [currentMonth, setCurrentMonth] = useState(
+    new Date(today.getFullYear(), today.getMonth(), 1)
+  );
+  const [earningCalls, setEarningCalls] = useState<EarningCall[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [scheduleData, setScheduleData] = useState<
+    Record<string, Array<{ time: string; event: string }>>
+  >({});
+
+  // API에서 어닝콜 데이터 가져오기
+  useEffect(() => {
+    const fetchEarningCalls = async () => {
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_BACK_API_URL}/earning-calls/member`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include", // 쿠키 기반 인증 사용
+          }
+        );
+
+        if (response.ok) {
+          const data: EarningCallResponse = await response.json();
+          setEarningCalls(data.data);
+
+          // 어닝콜 데이터를 scheduleData 형식으로 변환
+          const newScheduleData: Record<
+            string,
+            Array<{ time: string; event: string }>
+          > = {};
+          data.data.forEach((call) => {
+            const dateKey = call.earningCallDate;
+            if (!newScheduleData[dateKey]) {
+              newScheduleData[dateKey] = [];
+            }
+            newScheduleData[dateKey].push({
+              time: "어닝콜",
+              event: `${call.stockName} (${call.stockId}) 실적 발표`,
+            });
+          });
+          setScheduleData(newScheduleData);
+        } else {
+          console.error("API 응답 오류:", response.status, response.statusText);
+        }
+      } catch (error) {
+        console.error("어닝콜 데이터 가져오기 실패:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchEarningCalls();
+  }, []);
 
   const getDaysInMonth = (date: Date) => {
     const year = date.getFullYear();
@@ -57,7 +107,7 @@ export default function CalendarPage() {
 
   const hasSchedule = (day: number) => {
     const dateStr = formatDate(day);
-    return scheduleData[dateStr as keyof typeof scheduleData];
+    return scheduleData[dateStr];
   };
 
   const days = getDaysInMonth(currentMonth);
@@ -88,110 +138,130 @@ export default function CalendarPage() {
       </div>
 
       <main className="flex-1 overflow-y-auto pb-20">
-        {/* 달력 */}
-        <Card className="m-4">
-          <CardHeader>
-            <div className="flex items-center justify-between">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() =>
-                  setCurrentMonth(
-                    new Date(
-                      currentMonth.getFullYear(),
-                      currentMonth.getMonth() - 1,
-                      1
-                    )
-                  )
-                }
-              >
-                <ChevronLeft className="h-4 w-4" />
-              </Button>
-              <CardTitle>
-                {currentMonth.getFullYear()}년{" "}
-                {monthNames[currentMonth.getMonth()]}
-              </CardTitle>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() =>
-                  setCurrentMonth(
-                    new Date(
-                      currentMonth.getFullYear(),
-                      currentMonth.getMonth() + 1,
-                      1
-                    )
-                  )
-                }
-              >
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-            </div>
-          </CardHeader>
-          <CardContent>
-            <div className="grid grid-cols-7 gap-1 mb-2">
-              {["일", "월", "화", "수", "목", "금", "토"].map((day) => (
-                <div
-                  key={day}
-                  className="text-center text-sm font-medium text-gray-600 p-2"
-                >
-                  {day}
+        {loading ? (
+          <div className="flex items-center justify-center h-64">
+            <div className="text-gray-500">데이터를 불러오는 중...</div>
+          </div>
+        ) : (
+          <>
+            {/* 달력 */}
+            <Card className="m-4">
+              <CardHeader>
+                <div className="flex items-center justify-between">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      setCurrentMonth(
+                        new Date(
+                          currentMonth.getFullYear(),
+                          currentMonth.getMonth() - 1,
+                          1
+                        )
+                      )
+                    }
+                  >
+                    <ChevronLeft className="h-4 w-4" />
+                  </Button>
+                  <CardTitle>
+                    {currentMonth.getFullYear()}년{" "}
+                    {monthNames[currentMonth.getMonth()]}
+                  </CardTitle>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      setCurrentMonth(
+                        new Date(
+                          currentMonth.getFullYear(),
+                          currentMonth.getMonth() + 1,
+                          1
+                        )
+                      )
+                    }
+                  >
+                    <ChevronRight className="h-4 w-4" />
+                  </Button>
                 </div>
-              ))}
-            </div>
-            <div className="grid grid-cols-7 gap-1">
-              {days.map((day, index) => (
-                <div key={index} className="aspect-square">
-                  {day && (
-                    <Button
-                      variant={
-                        selectedDate === formatDate(day) ? "default" : "ghost"
-                      }
-                      size="sm"
-                      className={`w-full h-full text-sm relative ${
-                        hasSchedule(day) ? "bg-blue-50 hover:bg-blue-100" : ""
-                      }`}
-                      onClick={() => setSelectedDate(formatDate(day))}
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-7 gap-1 mb-2">
+                  {["일", "월", "화", "수", "목", "금", "토"].map((day) => (
+                    <div
+                      key={day}
+                      className="text-center text-sm font-medium text-gray-600 p-2"
                     >
                       {day}
-                      {hasSchedule(day) && (
-                        <div className="absolute bottom-1 left-1/2 transform -translate-x-1/2 w-1 h-1 bg-blue-600 rounded-full"></div>
-                      )}
-                    </Button>
-                  )}
-                </div>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
-
-        {/* 선택된 날짜의 일정 */}
-        <Card className="m-4">
-          <CardHeader>
-            <CardTitle className="text-lg">{selectedDate} 일정</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {scheduleData[selectedDate as keyof typeof scheduleData] ? (
-              <div className="space-y-3">
-                {scheduleData[selectedDate as keyof typeof scheduleData].map(
-                  (schedule, index) => (
-                    <div
-                      key={index}
-                      className="flex items-center space-x-3 p-2 bg-gray-50 rounded"
-                    >
-                      <div className="text-sm font-medium text-blue-600 min-w-[60px]">
-                        {schedule.time}
-                      </div>
-                      <div className="text-sm">{schedule.event}</div>
                     </div>
-                  )
+                  ))}
+                </div>
+                <div className="grid grid-cols-7 gap-1">
+                  {days.map((day, index) => (
+                    <div key={index} className="aspect-square">
+                      {day && (
+                        <Button
+                          variant={
+                            selectedDate === formatDate(day)
+                              ? "default"
+                              : "ghost"
+                          }
+                          size="sm"
+                          className={`w-full h-full text-sm relative ${
+                            hasSchedule(day)
+                              ? selectedDate === formatDate(day)
+                                ? "bg-blue-600 hover:bg-blue-700"
+                                : "bg-blue-50 hover:bg-blue-100"
+                              : ""
+                          }`}
+                          onClick={() => setSelectedDate(formatDate(day))}
+                        >
+                          {day}
+                          {hasSchedule(day) && (
+                            <div
+                              className={`absolute bottom-1 left-1/2 transform -translate-x-1/2 w-1 h-1 rounded-full ${
+                                selectedDate === formatDate(day)
+                                  ? "bg-white"
+                                  : "bg-blue-600"
+                              }`}
+                            ></div>
+                          )}
+                        </Button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* 선택된 날짜의 일정 */}
+            <Card className="m-4">
+              <CardHeader>
+                <CardTitle className="text-lg">{selectedDate} 일정</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {scheduleData[selectedDate] ? (
+                  <div className="space-y-3">
+                    {scheduleData[selectedDate].map((schedule, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center space-x-3 p-2 bg-gray-50 rounded"
+                      >
+                        <div className="text-sm font-medium text-blue-600 min-w-[60px]">
+                          {schedule.time}
+                        </div>
+                        <div className="text-sm">{schedule.event}</div>
+                      </div>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-gray-500 text-center py-4">
+                    일정이 없습니다.
+                  </p>
                 )}
-              </div>
-            ) : (
-              <p className="text-gray-500 text-center py-4">일정이 없습니다.</p>
-            )}
-          </CardContent>
-        </Card>
+              </CardContent>
+            </Card>
+          </>
+        )}
       </main>
 
       <BottomNavigation />

--- a/src/components/top-navigation.tsx
+++ b/src/components/top-navigation.tsx
@@ -26,10 +26,12 @@ export function TopNavigation({
   const shadowClass = shadow ? "shadow-md" : "";
 
   const isNotificationPage = pathname === "/notifications";
+  const isCalendarPage = pathname === "/calendar";
 
   return (
     <nav
-      className={`flex justify-between items-center p-4 bg-white ${borderClass} ${shadowClass}`}>
+      className={`flex justify-between items-center p-4 bg-white ${borderClass} ${shadowClass}`}
+    >
       <div className="flex items-center space-x-2">
         {showBackButton && (
           <Button variant="ghost" size="sm" onClick={() => router.back()}>
@@ -43,13 +45,19 @@ export function TopNavigation({
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => router.push("/calendar")}>
-            <Calendar className="h-5 w-5" />
+            onClick={() => router.push("/calendar")}
+          >
+            <Calendar
+              className={`h-5 w-5 transition-colors ${
+                isCalendarPage ? "text-blue-500 fill-blue-500" : "text-gray-600"
+              }`}
+            />
           </Button>
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => router.push("/notifications")}>
+            onClick={() => router.push("/notifications")}
+          >
             <Bell
               className={`h-5 w-5 transition-colors ${
                 isNotificationPage

--- a/src/types/ApiResponse.ts
+++ b/src/types/ApiResponse.ts
@@ -3,3 +3,19 @@ export interface ApiResponse<T> {
   message: string;
   data: T;
 }
+
+export interface EarningCall {
+  id: number;
+  stockId: string;
+  stockName: string;
+  earningCallDate: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface EarningCallResponse {
+  status: boolean;
+  code: string;
+  message: string;
+  data: EarningCall[];
+}


### PR DESCRIPTION
## 🔀 PR 개요
- 어닝콜 API 연동 구현
- 현재 날짜 기준으로 캘린더 표시
- 일정이 있는 날짜 스타일 개선
- 상단 네비게이션 캘린더 아이콘 활성화 상태 추가
- 일정 중복 추가 문제 해결 (state 관리 개선)

---

## ✅ 작업 내용
- 주요 변경사항 리스트
- 어떤 기능이 추가/변경/삭제되었는지 명확하게 작성

---

## 📌 관련 이슈
- Close #30  (자동으로 연결되도록)

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
