### PR TITLE
feat: 종목 상세 페이지 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "embla-carousel-react": "8.5.1",
     "framer-motion": "^12.23.5",
     "input-otp": "1.4.1",
+    "lightweight-charts": "^5.0.8",
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
     "next-themes": "^0.4.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       input-otp:
         specifier: 1.4.1
         version: 1.4.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      lightweight-charts:
+        specifier: ^5.0.8
+        version: 5.0.8
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.1.0)
@@ -1364,6 +1367,9 @@ packages:
   eventemitter3@4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
 
+  fancy-canvas@2.1.0:
+    resolution: {integrity: sha512-nifxXJ95JNLFR2NgRV4/MxVP45G9909wJTEKz5fg/TZS20JJZA6hfgRVh/bC9bwl2zBtBNcYPjiBE4njQHVBwQ==}
+
   fast-equals@5.2.2:
     resolution: {integrity: sha512-V7/RktU11J3I36Nwq2JnZEM7tNm17eBJz+u25qdxBZeCKiX6BkVSZQjwWIr+IobgnZy+ag73tTZgZi7tr0LrBw==}
     engines: {node: '>=6.0.0'}
@@ -1477,6 +1483,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  lightweight-charts@5.0.8:
+    resolution: {integrity: sha512-dNBK5TlNcG78RUnxYRAZP4XpY5bkp3EE0PPjFFPkdIZ8RvnvL2JLgTb1BLh40trHhgJl51b1bCz8678GpnKvIw==}
 
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
@@ -3112,6 +3121,8 @@ snapshots:
 
   eventemitter3@4.0.7: {}
 
+  fancy-canvas@2.1.0: {}
+
   fast-equals@5.2.2: {}
 
   fast-glob@3.3.3:
@@ -3213,6 +3224,10 @@ snapshots:
   jiti@1.21.7: {}
 
   js-tokens@4.0.0: {}
+
+  lightweight-charts@5.0.8:
+    dependencies:
+      fancy-canvas: 2.1.0
 
   lilconfig@3.1.3: {}
 

--- a/src/app/my-stocks/page.tsx
+++ b/src/app/my-stocks/page.tsx
@@ -18,7 +18,9 @@ type CompanyLogos = {
   [code: string]: string;
 };
 
-const getCompanyLogosByTicker = (stocks: StockItem[]): Record<string, string> => {
+const getCompanyLogosByTicker = (
+  stocks: StockItem[]
+): Record<string, string> => {
   const logos: Record<string, string> = {};
   stocks.forEach((stock) => {
     logos[stock.ticker.toString()] = `/ticker-icon/${stock.ticker}.png`;
@@ -26,7 +28,10 @@ const getCompanyLogosByTicker = (stocks: StockItem[]): Record<string, string> =>
   return logos;
 };
 
-async function fetchStockList(): Promise<{ stocks: StockItem[]; companyLogos: CompanyLogos }> {
+async function fetchStockList(): Promise<{
+  stocks: StockItem[];
+  companyLogos: CompanyLogos;
+}> {
   const res = await fetch(
     `${process.env.NEXT_PUBLIC_BACK_API_URL}/kis/unified-stocks`,
     {
@@ -38,7 +43,8 @@ async function fetchStockList(): Promise<{ stocks: StockItem[]; companyLogos: Co
     return { stocks: [], companyLogos: {} };
   }
   const json = await res.json();
-  const stocksRaw = json.data?.stocks || json.data?.stockList || json.data || [];
+  const stocksRaw =
+    json.data?.stocks || json.data?.stockList || json.data || [];
   const companyLogos = json.data?.companyLogos || {};
 
   const stocks: StockItem[] = stocksRaw.map((item: any) => ({
@@ -46,8 +52,11 @@ async function fetchStockList(): Promise<{ stocks: StockItem[]; companyLogos: Co
     name: item.prdt_name,
     quantity: item.quantity,
     avgPrice: Math.round((Number(item.avg_price) + Number.EPSILON) * 100) / 100,
-    profit_loss_amount: Math.round((Number(item.profit_loss_amount) + Number.EPSILON) * 100) / 100,
-    profit_loss_rate: Math.round((Number(item.profit_loss_rate) + Number.EPSILON) * 100) / 100,
+    profit_loss_amount:
+      Math.round((Number(item.profit_loss_amount) + Number.EPSILON) * 100) /
+      100,
+    profit_loss_rate:
+      Math.round((Number(item.profit_loss_rate) + Number.EPSILON) * 100) / 100,
   }));
   return { stocks, companyLogos };
 }
@@ -110,16 +119,18 @@ export default function MyStocksPage() {
               return (
                 <a
                   key={stock.ticker}
-                  href={`/stocks/${stock.ticker}`}
+                  href={`/stock/${stock.ticker}`}
                   className={[
                     "flex items-center py-2 px-5 hover:bg-[#f2f4f6] cursor-pointer transition mb-1 h-12 w-full",
                     idx === 0 ? "mt-2" : "",
-                    idx === stocks.length - 1 ? "mb-3" : ""
+                    idx === stocks.length - 1 ? "mb-3" : "",
                   ].join(" ")}
                   style={{
                     minWidth: "100%",
                     ...(idx === 0 ? { marginTop: "10px" } : {}),
-                    ...(idx === stocks.length - 1 ? { marginBottom: "12px" } : {}),
+                    ...(idx === stocks.length - 1
+                      ? { marginBottom: "12px" }
+                      : {}),
                   }}
                 >
                   <div
@@ -186,7 +197,8 @@ export default function MyStocksPage() {
                       className={`text-[11px] flex items-center font-medium mt-0.5 ${profitLossColor}`}
                       style={{ background: "none" }}
                     >
-                      {getProfitLossAmountString(stock.profit_loss_amount)}&nbsp;(
+                      {getProfitLossAmountString(stock.profit_loss_amount)}
+                      &nbsp;(
                       {getProfitLossRateString(stock.profit_loss_rate)})
                     </span>
                   </div>

--- a/src/app/stock/[code]/page.tsx
+++ b/src/app/stock/[code]/page.tsx
@@ -5,9 +5,9 @@ import { useParams } from "next/navigation";
 import { TopNavigation } from "@/src/components/top-navigation";
 import { BottomNavigation } from "@/src/components/bottom-navigation";
 import { StockHeader } from "@/src/components/stock-header";
-
 import { KeyStats } from "@/src/components/key-stats";
-
+import { UpcomingEvents } from "@/src/components/upcoming-events";
+import { StockChart } from "@/src/components/stock-chart";
 import { NewsSection } from "@/src/components/news-section";
 import type {
   OverseasStockDetail,
@@ -101,7 +101,13 @@ export default function EnhancedStockDetailPage() {
         {/* Stock Header - 종목명, 현재가, 등락률 */}
         <StockHeader stockData={stockData} stockCode={stockCode} />
 
-        {/* Key Statistics - 핵심 투자 지표 요약 */}
+        {/* 다가올 주요 이벤트 */}
+        <UpcomingEvents stockCode={stockCode} />
+
+        {/* 주가 차트 */}
+        <StockChart stockCode={stockCode} />
+
+        {/* 주요 지표 */}
         <KeyStats stockData={stockData} />
 
         {/* News Section - 관련 뉴스 */}

--- a/src/components/stock-chart.tsx
+++ b/src/components/stock-chart.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import { Button } from "@/src/components/ui/button";
+import { BarChart3, TrendingUp } from "lucide-react";
+
+interface StockChartProps {
+  stockCode: string;
+}
+
+type ChartPeriod = "1D" | "1W" | "1M" | "6M" | "1Y" | "ALL";
+
+export function StockChart({ stockCode }: StockChartProps) {
+  const [selectedPeriod, setSelectedPeriod] = useState<ChartPeriod>("1M");
+  const [loading, setLoading] = useState(true);
+
+  const periods: { value: ChartPeriod; label: string }[] = [
+    { value: "1D", label: "1일" },
+    { value: "1W", label: "1주" },
+    { value: "1M", label: "1개월" },
+    { value: "6M", label: "6개월" },
+    { value: "1Y", label: "1년" },
+    { value: "ALL", label: "전체" },
+  ];
+
+  // 임시 차트 데이터 생성
+  const generateMockData = (period: ChartPeriod) => {
+    const data = [];
+    const now = new Date();
+    const days =
+      period === "1D"
+        ? 24
+        : period === "1W"
+        ? 7
+        : period === "1M"
+        ? 30
+        : period === "6M"
+        ? 180
+        : period === "1Y"
+        ? 365
+        : 730;
+
+    for (let i = days; i >= 0; i--) {
+      const date = new Date(now);
+      date.setDate(date.getDate() - i);
+
+      const basePrice = 150 + Math.random() * 50;
+      const open = basePrice + (Math.random() - 0.5) * 10;
+      const high = open + Math.random() * 5;
+      const low = open - Math.random() * 5;
+      const close = open + (Math.random() - 0.5) * 8;
+
+      data.push({
+        time: date.getTime() / 1000,
+        open: parseFloat(open.toFixed(2)),
+        high: parseFloat(high.toFixed(2)),
+        low: parseFloat(low.toFixed(2)),
+        close: parseFloat(close.toFixed(2)),
+      });
+    }
+    return data;
+  };
+
+  useEffect(() => {
+    setLoading(true);
+    setTimeout(() => {
+      generateMockData(selectedPeriod);
+      setLoading(false);
+    }, 500);
+  }, [selectedPeriod]);
+
+  return (
+    <Card className="mx-4 mt-4 shadow-sm border-0 bg-white">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center text-gray-900">
+          <BarChart3 className="h-5 w-5 mr-2" />
+          주가 차트
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {/* 기간 선택 버튼 */}
+        <div className="flex space-x-1 mb-4 bg-gray-100 p-1 rounded-lg">
+          {periods.map((period) => (
+            <Button
+              key={period.value}
+              variant={selectedPeriod === period.value ? "default" : "ghost"}
+              size="sm"
+              className="flex-1 text-xs"
+              onClick={() => setSelectedPeriod(period.value)}
+            >
+              {period.label}
+            </Button>
+          ))}
+        </div>
+
+        {/* 차트 영역 */}
+        <div className="h-80 bg-white rounded-lg border border-gray-200">
+          {loading ? (
+            <div className="h-full flex items-center justify-center">
+              <div className="flex flex-col items-center space-y-2">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
+                <p className="text-sm text-gray-500">차트 로딩 중...</p>
+              </div>
+            </div>
+          ) : (
+            <div className="w-full h-full flex items-center justify-center">
+              <div className="text-center">
+                <TrendingUp className="h-12 w-12 text-gray-300 mx-auto mb-2" />
+                <p className="text-sm text-gray-500">
+                  {stockCode} 차트 ({selectedPeriod})
+                </p>
+                <p className="text-xs text-gray-400 mt-1">
+                  TradingView 차트가 여기에 표시됩니다
+                </p>
+                <div className="mt-4 p-3 bg-gray-50 rounded-lg">
+                  <p className="text-xs text-gray-500 mb-2">캔들스틱 차트</p>
+                  <div className="flex items-center justify-center space-x-1">
+                    <div className="w-2 h-8 bg-green-500"></div>
+                    <div className="w-2 h-4 bg-red-500"></div>
+                    <div className="w-2 h-6 bg-green-500"></div>
+                    <div className="w-2 h-10 bg-red-500"></div>
+                    <div className="w-2 h-5 bg-green-500"></div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* 차트 정보 */}
+        <div className="mt-4 grid grid-cols-3 gap-4 text-center">
+          <div>
+            <p className="text-xs text-gray-500 mb-1">시가</p>
+            <p className="font-semibold text-gray-900">$152.30</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 mb-1">고가</p>
+            <p className="font-semibold text-red-500">$158.45</p>
+          </div>
+          <div>
+            <p className="text-xs text-gray-500 mb-1">저가</p>
+            <p className="font-semibold text-blue-500">$149.80</p>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/stock-header.tsx
+++ b/src/components/stock-header.tsx
@@ -17,16 +17,20 @@ export function StockHeader({ stockData, stockCode }: StockHeaderProps) {
     return `$${num.toFixed(2)}`;
   };
 
-  const formatNumber = (value: string) => {
+  const formatLargeNumber = (value: string) => {
     const num = Number.parseFloat(value);
     if (isNaN(num)) return "0";
-    return num.toLocaleString();
+
+    if (num >= 1e12) return `$${(num / 1e12).toFixed(2)}T`;
+    if (num >= 1e9) return `$${(num / 1e9).toFixed(2)}B`;
+    if (num >= 1e6) return `$${(num / 1e6).toFixed(2)}M`;
+    return `$${num.toLocaleString()}`;
   };
 
   const getPriceChangeData = () => {
-    const currentPrice = Number.parseFloat(stockData.base || stockData.txprc);
+    const currentPrice = Number.parseFloat(stockData.last);
     const changePercent = Number.parseFloat(stockData.txrat);
-    const prevPrice = Number.parseFloat(stockData.last || stockData.pxprc);
+    const prevPrice = Number.parseFloat(stockData.base);
     const changeAmount = currentPrice - prevPrice;
 
     const isPositive = changePercent >= 0;
@@ -64,7 +68,10 @@ export function StockHeader({ stockData, stockCode }: StockHeaderProps) {
               {stockCode}
             </p>
           </div>
-          <Badge variant="secondary" className="text-xs font-medium">
+          <Badge
+            variant="secondary"
+            className="text-xs font-medium whitespace-nowrap"
+          >
             {stockData.eicod || "해외주식"}
           </Badge>
         </div>
@@ -73,7 +80,7 @@ export function StockHeader({ stockData, stockCode }: StockHeaderProps) {
         <div className="flex items-end justify-between">
           <div>
             <p className="text-3xl font-bold text-gray-900 mb-1">
-              {formatCurrency(stockData.base || stockData.txprc)}
+              {formatCurrency(stockData.last || stockData.txprc)}
             </p>
             <p className="text-sm text-gray-500">현재가</p>
           </div>
@@ -103,9 +110,9 @@ export function StockHeader({ stockData, stockCode }: StockHeaderProps) {
             </div>
             <div className="h-8 w-px bg-gray-200"></div>
             <div>
-              <p className="text-xs text-gray-500 mb-1">거래량</p>
+              <p className="text-xs text-gray-500 mb-1">자본금</p>
               <p className="font-semibold text-gray-900">
-                {formatNumber(stockData.pvol)}
+                {formatLargeNumber(stockData.mcap)}
               </p>
             </div>
           </div>

--- a/src/components/upcoming-events.tsx
+++ b/src/components/upcoming-events.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/src/components/ui/card";
+import { Calendar } from "lucide-react";
+import { EarningCall } from "@/src/types/ApiResponse";
+
+interface UpcomingEvent {
+  id: string;
+  title: string;
+  date: string;
+  daysUntil: number;
+  type: "earnings";
+}
+
+interface UpcomingEventsProps {
+  stockCode: string;
+}
+
+export function UpcomingEvents({ stockCode }: UpcomingEventsProps) {
+  const router = useRouter();
+  const [events, setEvents] = useState<UpcomingEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchEarningCalls = async () => {
+      try {
+        setLoading(true);
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_BACK_API_URL}/earning-calls/member`,
+          {
+            method: "GET",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            credentials: "include",
+          }
+        );
+
+        if (response.ok) {
+          const data = await response.json();
+          const earningCalls: EarningCall[] = data.data || [];
+
+          // 현재 종목의 어닝콜만 필터링
+          const currentStockCalls = earningCalls.filter(
+            (call) => call.stockId === stockCode
+          );
+
+          // 날짜별로 정렬하고 가장 가까운 2개만 선택
+          const sortedCalls = currentStockCalls
+            .sort(
+              (a, b) =>
+                new Date(a.earningCallDate).getTime() -
+                new Date(b.earningCallDate).getTime()
+            )
+            .slice(0, 2);
+
+          // UpcomingEvent 형태로 변환
+          const upcomingEvents: UpcomingEvent[] = sortedCalls.map((call) => {
+            const eventDate = new Date(call.earningCallDate);
+            const today = new Date();
+            const timeDiff = eventDate.getTime() - today.getTime();
+            const daysUntil = Math.ceil(timeDiff / (1000 * 3600 * 24));
+
+            return {
+              id: call.id.toString(),
+              title: `${call.ovrsItemName} 실적 발표`,
+              date: call.earningCallDate,
+              daysUntil: daysUntil > 0 ? daysUntil : 0,
+              type: "earnings" as const,
+            };
+          });
+
+          setEvents(upcomingEvents);
+        } else {
+          console.error("어닝콜 데이터 가져오기 실패:", response.status);
+        }
+      } catch (error) {
+        console.error("어닝콜 데이터 가져오기 실패:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (stockCode) {
+      fetchEarningCalls();
+    }
+  }, [stockCode]);
+
+  const getEventIcon = (type: string) => {
+    switch (type) {
+      case "earnings":
+        return "📊";
+      default:
+        return "📅";
+    }
+  };
+
+  const getEventColor = (type: string) => {
+    switch (type) {
+      case "earnings":
+        return "bg-blue-50 border-blue-200 text-blue-800";
+      default:
+        return "bg-gray-50 border-gray-200 text-gray-800";
+    }
+  };
+
+  if (loading) {
+    return (
+      <Card className="mx-4 mt-4 shadow-sm border-0 bg-white">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg flex items-center text-gray-900">
+            <Calendar className="h-5 w-5 mr-2" />
+            다가올 주요 이벤트
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-4">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-500"></div>
+            <span className="ml-2 text-sm text-gray-500">
+              이벤트 로딩 중...
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (events.length === 0) {
+    return (
+      <Card className="mx-4 mt-4 shadow-sm border-0 bg-white">
+        <CardHeader className="pb-3">
+          <CardTitle className="text-lg flex items-center text-gray-900">
+            <Calendar className="h-5 w-5 mr-2" />
+            다가올 주요 이벤트
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-center py-6">
+            <p className="text-gray-500 text-sm">가까운 이벤트가 없습니다.</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="mx-4 mt-4 shadow-sm border-0 bg-white">
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg flex items-center text-gray-900">
+          <Calendar className="h-5 w-5 mr-2" />
+          다가올 주요 이벤트
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {events.map((event) => (
+            <div
+              key={event.id}
+              className={`flex items-center justify-between p-3 rounded-lg border ${getEventColor(
+                event.type
+              )} cursor-pointer hover:opacity-80 transition-opacity`}
+              onClick={() => router.push("/calendar")}
+            >
+              <div className="flex items-center space-x-3">
+                <span className="text-lg">{getEventIcon(event.type)}</span>
+                <div>
+                  <p className="font-medium text-sm">{event.title}</p>
+                  <p className="text-xs opacity-75">{event.date}</p>
+                </div>
+              </div>
+              <div className="text-right">
+                <p className="font-bold text-sm">D-{event.daysUntil}</p>
+                <p className="text-xs opacity-75">남음</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## 🔀 PR 개요
- 종목 상세 페이지 UI 개선
- 주요 이벤트 구현

---

## ✅ 작업 내용
- StockHeader: 현재가, 등락률, 자본금 표시 개선
- KeyStats: 자본금 필드 추가, 투자 비율 섹션 유지
- UpcomingEvents: 실제 어닝콜 데이터 연동, 클릭 시 달력 페이지 이동
- StockChart: 기간 선택 및 차트 영역 구현
- 종목 상세 페이지 레이아웃 완성

---

## 📌 관련 이슈
- Close #39 

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 차트, 뉴스는 아직 적용 안함
