### PR TITLE
Feat/UI responsive layout

### DIFF
--- a/src/app/calendar/CalendarClient.tsx
+++ b/src/app/calendar/CalendarClient.tsx
@@ -165,8 +165,9 @@ export default function CalendarPage() {
 
   return (
     <div className="flex flex-col h-screen bg-gray-100">
-      <TopNavigation title="일정test" />
+      <TopNavigation title="BLML" />
       <main className="flex-1 overflow-y-auto pb-20">
+      <div className="max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl mx-auto w-full px-2">
         {loading ? (
           <div className="flex items-center justify-center h-64">
             <div className="text-gray-500">데이터를 불러오는 중...</div>
@@ -291,6 +292,7 @@ export default function CalendarPage() {
             </Card>
           </>
         )}
+        </div>
       </main>
       <BottomNavigation />
     </div>

--- a/src/app/cards/page.tsx
+++ b/src/app/cards/page.tsx
@@ -204,7 +204,7 @@ export default function CardsPage() {
   };
 
   return (
-    <div className="flex flex-col h-screen max-w-[480px] mx-auto bg-white overflow-hidden">
+    <div className="flex flex-col h-screen mx-auto bg-white overflow-hidden">
       <TopNavigation />
       <SelectedDateDisplay date={selectedDate} />
       <div className="relative flex-1">

--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -349,8 +349,8 @@ export default function HomePage() {
   return (
     <div className="flex flex-col h-screen bg-gray-100">
       <TopNavigation title="" />
-      <main className="flex-1 overflow-y-auto p-4 pb-20">
-        <div style={getSectionStyle(0)}>
+      <main className="flex-1 overflow-y-auto pb-20 p-0">
+        <div className="max-w-[700px] w-full mx-auto px-4" style={getSectionStyle(0)}>
           <NewsSlider
             newsItems={newsItems}
             newsIndex={newsIndex}
@@ -358,20 +358,20 @@ export default function HomePage() {
             onClick={() => handleSlide("up")}
           />
         </div>
-        <div style={getSectionStyle(1)}>
+        <div className="max-w-[700px] w-full mx-auto px-4" style={getSectionStyle(1)}>
           <AssetSummary assetAmount={assetAmount} />
         </div>
-        <div style={getSectionStyle(2)}>
+        <div className="max-w-[700px] w-full mx-auto px-4" style={getSectionStyle(2)}>
           <StockList stocks={stocks} companyLogos={logos} />
         </div>
-        <div style={getSectionStyle(3)}>
+        <div className="max-w-[700px] w-full mx-auto px-4" style={getSectionStyle(3)}>
           <AssetChart assetTrendData={assetTrendData} />
           <Card
             className="mb-2 rounded-xl border-0 w-full"
             style={{ maxWidth: "800px", margin: "0 auto" }}
           />
         </div>
-        <div style={getSectionStyle(4)}>
+        <div className="max-w-[700px] w-full mx-auto px-4" style={getSectionStyle(4)}>
           <InfoTabs
             tab={tab}
             setTab={setTab}

--- a/src/app/notifications/page.tsx
+++ b/src/app/notifications/page.tsx
@@ -60,7 +60,7 @@ export default function NotificationsPage() {
     <div className="flex flex-col h-screen bg-[#f9fafb]">
       <TopNavigation />
       <main className="flex-1 overflow-y-auto pb-20">
-        <div className="space-y-3 p-4">
+        <div className="space-y-3 p-4 max-w-md md:max-w-lg lg:max-w-2xl xl:max-w-3xl mx-auto">
           {notifications
             .slice()
             .reverse()

--- a/src/app/scrap/page.tsx
+++ b/src/app/scrap/page.tsx
@@ -248,8 +248,8 @@ export default function ScrapPage() {
       </div>
 
       <main className="flex-1 overflow-y-auto pb-24 bg-gray-50 ">
-      <div className="max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl mx-auto w-full px-2">
-        {activeTab === "stocks" ? renderStocksTab() : renderGroupsTab()}
+        <div className="max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl mx-auto w-full px-2">
+          {activeTab === "stocks" ? renderStocksTab() : renderGroupsTab()}
         </div>
       </main>
 

--- a/src/app/scrap/page.tsx
+++ b/src/app/scrap/page.tsx
@@ -221,33 +221,36 @@ export default function ScrapPage() {
   };
 
   return (
-    <div className="flex flex-col h-screen max-w-[480px] mx-auto bg-white relative">
+    <div className="flex flex-col h-screen mx-auto bg-white relative">
       <TopNavigation />
 
       <div className="px-4 pt-3 pb-2 border-b bg-white">
-        <h1 className="text-lg font-bold flex items-center mb-3"></h1>
-        <div className="flex bg-gray-100 rounded-lg p-1 gap-1">
-          <Button
-            variant={activeTab === "stocks" ? "default" : "ghost"}
-            size="sm"
-            className="flex-1 rounded-md"
-            onClick={() => setActiveTab("stocks")}
-          >
-            종목
-          </Button>
-          <Button
-            variant={activeTab === "groups" ? "default" : "ghost"}
-            size="sm"
-            className="flex-1 rounded-md"
-            onClick={() => setActiveTab("groups")}
-          >
-            그룹
-          </Button>
+        <div className="max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl mx-auto w-full px-2">
+          <div className="flex bg-gray-100 rounded-lg p-1 gap-1">
+            <Button
+              variant={activeTab === "stocks" ? "default" : "ghost"}
+              size="sm"
+              className="flex-1 rounded-md"
+              onClick={() => setActiveTab("stocks")}
+            >
+              종목
+            </Button>
+            <Button
+              variant={activeTab === "groups" ? "default" : "ghost"}
+              size="sm"
+              className="flex-1 rounded-md"
+              onClick={() => setActiveTab("groups")}
+            >
+              그룹
+            </Button>
+          </div>
         </div>
       </div>
 
-      <main className="flex-1 overflow-y-auto pb-24 bg-gray-50">
+      <main className="flex-1 overflow-y-auto pb-24 bg-gray-50 ">
+      <div className="max-w-md md:max-w-lg lg:max-w-xl xl:max-w-2xl mx-auto w-full px-2">
         {activeTab === "stocks" ? renderStocksTab() : renderGroupsTab()}
+        </div>
       </main>
 
       <BottomNavigation />

--- a/src/components/bottom-navigation.tsx
+++ b/src/components/bottom-navigation.tsx
@@ -17,7 +17,7 @@ export function BottomNavigation() {
   const pathname = usePathname();
 
   return (
-    <nav className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full max-w-sm bg-white border-t rounded-t-lg border-gray-stroke-100">
+    <nav className="fixed bottom-0 left-1/2 transform -translate-x-1/2 w-full bg-white border-t rounded-t-lg border-gray-stroke-100">
       <div className="flex">
         {NAV_ITEMS.map(({ icon: Icon, label, path }) => {
           const isActive =

--- a/src/components/conditional-layout.tsx
+++ b/src/components/conditional-layout.tsx
@@ -17,7 +17,7 @@ export default function ConditionalLayout({
 
   return (
     <div className="min-h-screen bg-gray-50 flex justify-center">
-      <div className="w-full max-w-sm bg-white shadow-lg">{children}</div>
+      <div className="w-full bg-white shadow-lg">{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
## 🔀 PR 개요
- 주요 페이지에 반응형 레이아웃을 적용하였습니다.

---

## ✅ 작업 내용
- 로그인 페이지 반응형 레이아웃 적용
- 알림(notification) 페이지 반응형 적용
- 스크랩(scrap), 카드(cards) 페이지 반응형 적용
- 홈(home), 캘린더(calendar) 페이지 반응형 레이아웃 적용
- 전체적으로 헤더/푸터는 full-width, 내부 콘텐츠는 max-width 구조로 개선

---

## 📌 관련 이슈
- Close #71 

---

## 📸 스크린샷
<img width="1440" height="787" alt="image" src="https://github.com/user-attachments/assets/20f1b739-9255-4103-a18e-7f1ce7f89379" />


