### PR TITLE
Feat/total summary render

### DIFF
--- a/src/app/home/page.tsx
+++ b/src/app/home/page.tsx
@@ -25,10 +25,25 @@ export type StockItem = {
   quantity: number;
   currentPrice: number;
 };
-export type DisclosureItem = { id: number; disclosureTitle: string; disclosureDate: string; stockId: string; stockName: string };
-export type EarningCallItem = { earningCallId: number; ticker: string; date: string; ovrsItemName: string };
+export type DisclosureItem = {
+  id: number;
+  disclosureTitle: string;
+  disclosureDate: string;
+  stockId: string;
+  stockName: string;
+};
+export type EarningCallItem = {
+  earningCallId: number;
+  ticker: string;
+  date: string;
+  ovrsItemName: string;
+};
 export type NewsListResponse = { news: NewsItem[] };
-export type StockListResponse = { stocks: StockItem[]; companyLogos: Record<string, string>; summary?: { total_purchase_amount: number } };
+export type StockListResponse = {
+  stocks: StockItem[];
+  companyLogos: Record<string, string>;
+  summary?: { total_purchase_amount: number };
+};
 export type DisclosureListResponse = { data: DisclosureItem[] };
 export type MemberResponse = { memberName: string; memberNickname: string };
 export type EarningCallListResponse = { earningCalls: EarningCallItem[] };
@@ -63,7 +78,9 @@ async function fetchWithAuthCheck<T>(
   return jsonResponse;
 }
 
-const fetchMember = async (router: ReturnType<typeof useRouter>): Promise<MemberResponse> => {
+const fetchMember = async (
+  router: ReturnType<typeof useRouter>
+): Promise<MemberResponse> => {
   const jsonResponse = await fetchWithAuthCheck<any>(
     `${process.env.NEXT_PUBLIC_BACK_API_URL}/member/info`,
     {
@@ -72,10 +89,15 @@ const fetchMember = async (router: ReturnType<typeof useRouter>): Promise<Member
     },
     router
   );
-  return { memberName: jsonResponse.data.memberName, memberNickname: jsonResponse.data.memberNickname };
+  return {
+    memberName: jsonResponse.data.memberName,
+    memberNickname: jsonResponse.data.memberNickname,
+  };
 };
 
-export async function fetchNewsList(router: ReturnType<typeof useRouter>): Promise<NewsListResponse> {
+export async function fetchNewsList(
+  router: ReturnType<typeof useRouter>
+): Promise<NewsListResponse> {
   const jsonResponse = await fetchWithAuthCheck<any>(
     `${process.env.NEXT_PUBLIC_BACK_API_URL}/main-news/current`,
     {},
@@ -129,7 +151,9 @@ export async function fetchStockList(
   };
 }
 
-const fetchDisclosureList = async (router: ReturnType<typeof useRouter>): Promise<DisclosureListResponse> => {
+const fetchDisclosureList = async (
+  router: ReturnType<typeof useRouter>
+): Promise<DisclosureListResponse> => {
   const jsonResponse = await fetchWithAuthCheck<any>(
     `${process.env.NEXT_PUBLIC_BACK_API_URL}/disclosure/my-current-disclosure`,
     {
@@ -143,7 +167,9 @@ const fetchDisclosureList = async (router: ReturnType<typeof useRouter>): Promis
   return jsonResponse;
 };
 
-export async function fetchEarningCallList(router: ReturnType<typeof useRouter>): Promise<EarningCallListResponse> {
+export async function fetchEarningCallList(
+  router: ReturnType<typeof useRouter>
+): Promise<EarningCallListResponse> {
   const jsonResponse = await fetchWithAuthCheck<any>(
     `${process.env.NEXT_PUBLIC_BACK_API_URL}/earning-calls/member/upcoming`,
     {
@@ -152,13 +178,16 @@ export async function fetchEarningCallList(router: ReturnType<typeof useRouter>)
     },
     router
   );
-  if (jsonResponse.code !== "EARNING-004") throw new Error("어닝콜 데이터를 불러오지 못했습니다.");
-  const mappedData: EarningCallItem[] = (jsonResponse.data || []).map((item: any) => ({
-    earningCallId: item.id,
-    ticker: item.stockId,
-    date: item.earningCallDate,
-    ovrsItemName: item.ovrsItemName
-  }));
+  if (jsonResponse.code !== "EARNING-004")
+    throw new Error("어닝콜 데이터를 불러오지 못했습니다.");
+  const mappedData: EarningCallItem[] = (jsonResponse.data || []).map(
+    (item: any) => ({
+      earningCallId: item.id,
+      ticker: item.stockId,
+      date: item.earningCallDate,
+      ovrsItemName: item.ovrsItemName,
+    })
+  );
   return { earningCalls: mappedData };
 }
 
@@ -251,7 +280,9 @@ export default function HomePage() {
 
     fetchEarningCallList(router)
       .then((res) => {
-        setEarningCallData(Array.isArray(res.earningCalls) ? res.earningCalls : []);
+        setEarningCallData(
+          Array.isArray(res.earningCalls) ? res.earningCalls : []
+        );
       })
       .catch(() => {
         setEarningCallData([]);
@@ -318,8 +349,7 @@ export default function HomePage() {
       <main className="flex-1 overflow-y-auto pb-20 p-0">
         <div
           className="max-w-[700px] w-full mx-auto px-4"
-          style={getSectionStyle(0)}
-        >
+          style={getSectionStyle(0)}>
           <NewsSlider
             newsItems={newsItems}
             newsIndex={newsIndex}
@@ -329,48 +359,40 @@ export default function HomePage() {
         </div>
         <div
           className="max-w-[700px] w-full mx-auto px-4"
-          style={getSectionStyle(1)}
-        >
+          style={getSectionStyle(1)}>
           <AssetSummary assetAmount={assetAmount} />
         </div>
         <div
           className="max-w-[700px] w-full mx-auto px-4"
-          style={getSectionStyle(2)}
-        >
+          style={getSectionStyle(2)}>
           <StockList stocks={stocksForStockList} companyLogos={logos} />
         </div>
         <div
           className="max-w-[700px] w-full mx-auto px-4"
-          style={getSectionStyle(3)}
-        >
-          <div className="max-w-[700px] w-full mx-auto px-4 mt-5 mb-2 font-medium text-gray-800" style={getSectionStyle(2)}>
+          style={getSectionStyle(3)}>
+          <div
+            className="max-w-[700px] w-full mx-auto px-4 mt-5 mb-2 font-medium text-gray-800"
+            style={getSectionStyle(2)}>
             {name}님을 위한 오늘의 코멘트예요
           </div>
           <AssetChart />
         </div>
         <div
           className="max-w-[700px] w-full mx-auto px-4"
-          style={getSectionStyle(4)}
-        >
+          style={getSectionStyle(4)}>
           <InfoTabs
             tab={tab}
             setTab={setTab}
-            disclosureData={disclosureData
-              .slice(0, 3)
-              .map((item) => ({
-                id: item.id,
-                title: item.disclosureTitle,
-                date: getRelativeTime(item.disclosureDate),
-              }))
-            }
-            earningCallData={earningCallData
-              .slice(0, 3)
-              .map((item) => ({
-                id: item.earningCallId,
-                title: item.ovrsItemName,
-                date: getRelativeTime(item.date),
-              }))
-            }
+            disclosureData={disclosureData.slice(0, 3).map((item) => ({
+              id: item.id,
+              title: item.disclosureTitle,
+              date: getRelativeTime(item.disclosureDate),
+            }))}
+            earningCallData={earningCallData.slice(0, 3).map((item) => ({
+              id: item.earningCallId,
+              title: item.ovrsItemName,
+              date: getRelativeTime(item.date),
+            }))}
           />
         </div>
       </main>

--- a/src/components/ui/asset-chart.tsx
+++ b/src/components/ui/asset-chart.tsx
@@ -64,38 +64,17 @@ const useStocks = () => {
   return { stocks, loading };
 };
 
-// const useSummaryString = () => {
-//   const [summary, setSummary] = useState("");
-//   useEffect(() => {
-//     let mounted = true;
-//     fetchTodayComment().then((result) => {
-//       if (mounted) setSummary(result);
-//     });
-//     return () => {
-//       mounted = false;
-//     };
-//   }, []);
-//   return summary;
-// };
 const useSummaryString = () => {
-  // mock 마크다운 형식 총평
-  const mockSummary = `
-📉 테슬라 하락
-전기차 수요 둔화로 오늘 테슬라는 -4.2% 하락했습니다.
-
-📈 애플 어닝 서프라이즈
-예상치를 웃도는 실적으로 2.1% 상승세를 기록했습니다.
-
-💡 오늘의 투자 코멘트
-기술주 중심의 포트폴리오라면 단기 리밸런싱을 고려해보세요.
-  `;
-
   const [summary, setSummary] = useState("");
-
   useEffect(() => {
-    setSummary(mockSummary);
+    let mounted = true;
+    fetchTodayComment().then((result) => {
+      if (mounted) setSummary(result);
+    });
+    return () => {
+      mounted = false;
+    };
   }, []);
-
   return summary;
 };
 

--- a/src/components/ui/asset-chart.tsx
+++ b/src/components/ui/asset-chart.tsx
@@ -3,20 +3,21 @@ import { StockItem, fetchStockList } from "@/src/app/home/page";
 import React, { useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { PieChart, Pie, Cell, Tooltip, ResponsiveContainer } from "recharts";
+import SummarySlider from "@/src/components/ui/summary-slider";
 
 const COLORS = [
-  "#A7C7E7", 
+  "#A7C7E7",
   "#B5D0EB",
   "#CFE2F3",
-  "#D6EAF8", 
-  "#B3E0FF", 
-  "#B6D4FA", 
+  "#D6EAF8",
+  "#B3E0FF",
+  "#B6D4FA",
   "#7DA7D9",
-  "#5B8DB8", 
+  "#5B8DB8",
   "#3B6FA1",
   "#3498FF",
-  "#0074D9", 
-  "#1E90FF", 
+  "#0074D9",
+  "#1E90FF",
   "#0099FF",
 ];
 
@@ -24,7 +25,11 @@ const fetchTodayComment = async (): Promise<string> => {
   try {
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_BACK_API_URL}/total-summary/today-summary`,
-      { method: "GET", headers: { "Content-Type": "application/json" }, credentials: "include" }
+      {
+        method: "GET",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+      }
     );
     const jsonResponse = await response.json();
     return jsonResponse?.data?.totalSummary ?? "";
@@ -51,38 +56,64 @@ const useStocks = () => {
       .finally(() => {
         if (mounted) setLoading(false);
       });
-    return () => { mounted = false; };
+    return () => {
+      mounted = false;
+    };
   }, [router]);
 
   return { stocks, loading };
 };
 
+// const useSummaryString = () => {
+//   const [summary, setSummary] = useState("");
+//   useEffect(() => {
+//     let mounted = true;
+//     fetchTodayComment().then((result) => {
+//       if (mounted) setSummary(result);
+//     });
+//     return () => {
+//       mounted = false;
+//     };
+//   }, []);
+//   return summary;
+// };
 const useSummaryString = () => {
+  // mock 마크다운 형식 총평
+  const mockSummary = `
+📉 테슬라 하락
+전기차 수요 둔화로 오늘 테슬라는 -4.2% 하락했습니다.
+
+📈 애플 어닝 서프라이즈
+예상치를 웃도는 실적으로 2.1% 상승세를 기록했습니다.
+
+💡 오늘의 투자 코멘트
+기술주 중심의 포트폴리오라면 단기 리밸런싱을 고려해보세요.
+  `;
+
   const [summary, setSummary] = useState("");
+
   useEffect(() => {
-    let mounted = true;
-    fetchTodayComment().then((result) => {
-      if (mounted) setSummary(result);
-    });
-    return () => { mounted = false; };
+    setSummary(mockSummary);
   }, []);
+
   return summary;
 };
 
 const useFilteredStocks = (stocks: StockItem[]) => {
   return useMemo(() => {
-    if (!stocks || !Array.isArray(stocks)) return { filteredStocks: [], filteredAmounts: [] };
+    if (!stocks || !Array.isArray(stocks))
+      return { filteredStocks: [], filteredAmounts: [] };
 
     const filteredStocks = stocks
-      .map(stock => {
+      .map((stock) => {
         const quantity = parseFloat(stock.quantity as unknown as string) || 0;
         const currentPrice = parseFloat(stock.currentPrice as any) || 0;
         const amount = parseFloat((quantity * currentPrice).toFixed(2)); // 소숫점 둘째자리까지 반영
         return { ...stock, quantity, amount };
       })
-      .filter(stock => stock.amount > 0);
+      .filter((stock) => stock.amount > 0);
 
-    const filteredAmounts = filteredStocks.map(stock => stock.amount);
+    const filteredAmounts = filteredStocks.map((stock) => stock.amount);
     return { filteredStocks, filteredAmounts };
   }, [stocks]);
 };
@@ -90,6 +121,26 @@ const useFilteredStocks = (stocks: StockItem[]) => {
 export default function AssetChart() {
   const { stocks, loading } = useStocks();
   const summaryString = useSummaryString();
+  const parsedSummaries = useMemo(() => {
+    const parsed = summaryString
+      .trim()
+      .split(/\n\s*\n/) // 줄 두 개 이상 + 공백 가능
+      .map((block, idx) => {
+        const lines = block
+          .trim()
+          .split("\n")
+          .map((line) => line.trim());
+        const title = lines[0];
+        const content = lines.slice(1).join(" ").trim();
+
+        return { id: idx, title, content };
+      })
+      .filter((item) => item.title && item.content);
+
+    console.log("✅ parsedSummaries", parsed);
+    return parsed;
+  }, [summaryString]);
+
   const { filteredStocks, filteredAmounts } = useFilteredStocks(stocks);
 
   // Recharts용 데이터 포맷팅
@@ -112,30 +163,50 @@ export default function AssetChart() {
         boxShadow: "0 4px 24px 0 rgba(180, 210, 255, 0.18)",
         // background: "#fff", // 배경 제거
         // border: "1px solid #e3e8f0", // 테두리 제거
-      }}
-    >
+      }}>
       <CardContent className="rounded-xl p-0">
-        <div style={{ display: "flex", width: "100%", gap: 8, minHeight: 140, maxHeight: 180 }}>
-          <div style={{ width: "50%", minWidth: 0, display: "flex", alignItems: "center", justifyContent: "center", position: "relative" }}>
+        <div
+          style={{
+            display: "flex",
+            width: "100%",
+            gap: 8,
+            minHeight: 140,
+            maxHeight: 180,
+          }}>
+          <div
+            style={{
+              width: "50%",
+              minWidth: 0,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              position: "relative",
+            }}>
             {/* 도넛 뒤 그림자 */}
-            <div style={{
-              position: "absolute",
-              left: "50%",
-              top: "50%",
-              width: 120,
-              height: 120,
-              transform: "translate(-50%, -50%)",
-              borderRadius: "50%",
-              boxShadow: "0 8px 32px 0 rgba(100,150,255,0.10)",
-              background: "transparent",
-              zIndex: 0,
-            }} />
+            <div
+              style={{
+                position: "absolute",
+                left: "50%",
+                top: "50%",
+                width: 120,
+                height: 120,
+                transform: "translate(-50%, -50%)",
+                borderRadius: "50%",
+                boxShadow: "0 8px 32px 0 rgba(100,150,255,0.10)",
+                background: "transparent",
+                zIndex: 0,
+              }}
+            />
             {/* 차트 */}
             <div style={{ width: "100%", zIndex: 1 }}>
               {loading ? (
-                <div style={{ color: "#888", fontSize: 16 }}>주식 데이터를 불러오는 중입니다...</div>
+                <div style={{ color: "#888", fontSize: 16 }}>
+                  주식 데이터를 불러오는 중입니다...
+                </div>
               ) : filteredAmounts.length === 0 ? (
-                <div style={{ color: "#888", fontSize: 16 }}>보유한 주식이 없습니다.</div>
+                <div style={{ color: "#888", fontSize: 16 }}>
+                  보유한 주식이 없습니다.
+                </div>
               ) : (
                 <ResponsiveContainer width="100%" height={140}>
                   <PieChart>
@@ -148,22 +219,24 @@ export default function AssetChart() {
                       paddingAngle={0}
                       labelLine={false}
                       isAnimationActive={false}
-                      focusable={false} 
-                      tabIndex={-1}               
-                    >
+                      focusable={false}
+                      tabIndex={-1}>
                       {chartData.map((entry, index) => (
                         <Cell key={`cell-${index}`} fill={entry.color} />
                       ))}
                     </Pie>
                     <Tooltip
-                      formatter={(value: number, name: string) => [`${value.toLocaleString()}$`, name]}
+                      formatter={(value: number, name: string) => [
+                        `${value.toLocaleString()}$`,
+                        name,
+                      ]}
                       contentStyle={{ fontSize: 14 }}
                     />
                     <style jsx global>{`
                       .recharts-pie-sector:focus {
                         outline: none !important;
-                        stroke: #e3e8f0 !important;   /* 아주 연한 회색 */
-                        stroke-width: 1 !important;   /* 얇게 */
+                        stroke: #e3e8f0 !important; /* 아주 연한 회색 */
+                        stroke-width: 1 !important; /* 얇게 */
                       }
                       .recharts-pie-sector:hover {
                         filter: brightness(1.08);
@@ -189,10 +262,13 @@ export default function AssetChart() {
               borderBottomRightRadius: 16,
               display: "flex",
               alignItems: "center",
-            }}
-          >
+            }}>
             <div style={{ whiteSpace: "pre-line", wordBreak: "break-word" }}>
-              {summaryString || "오늘의 요약 정보를 불러오는 중입니다."}
+              {parsedSummaries.length > 0 ? (
+                <SummarySlider summaries={parsedSummaries} />
+              ) : (
+                "오늘의 요약 정보를 불러오는 중입니다."
+              )}
             </div>
           </div>
         </div>

--- a/src/components/ui/summary-slider.tsx
+++ b/src/components/ui/summary-slider.tsx
@@ -18,7 +18,7 @@ export default function SummarySlider({ summaries }: SummarySliderProps) {
   useEffect(() => {
     const timer = setInterval(() => {
       setCurrentIndex((prev) => (prev + 1) % summaries.length);
-    }, 2500);
+    }, 4000);
     return () => clearInterval(timer);
   }, [summaries.length]);
 

--- a/src/components/ui/summary-slider.tsx
+++ b/src/components/ui/summary-slider.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type SummaryItem = {
+  id: number;
+  title: string;
+  content: string;
+};
+
+interface SummarySliderProps {
+  summaries: SummaryItem[];
+}
+
+export default function SummarySlider({ summaries }: SummarySliderProps) {
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setCurrentIndex((prev) => (prev + 1) % summaries.length);
+    }, 2500);
+    return () => clearInterval(timer);
+  }, [summaries.length]);
+
+  return (
+    <div className="relative w-full h-[80px] overflow-hidden">
+      <div
+        className="transition-transform duration-500 ease-in-out"
+        style={{
+          transform: `translateY(-${currentIndex * 80}px)`, // 한 문단 높이만큼 정확히
+        }}>
+        {summaries.map((summary) => (
+          <div
+            key={summary.id}
+            className="h-[80px] px-2 flex flex-col justify-center">
+            <h3 className="text-base font-semibold mb-1">{summary.title}</h3>
+            <p className="text-sm text-gray-700">{summary.content}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🔀 PR 개요
- 오늘의 총평 데이터를 마크다운 형식으로 렌더링하고 시각적으로 표현하는 UI 추가

---

## ✅ 작업 내용
- 마크다운 형식 총평 문자열을 파싱하여 SummarySlider 컴포넌트에 전달

---

## 📌 관련 이슈
- Close #114 

---

## 📸 스크린샷
<img width="696" height="191" alt="image" src="https://github.com/user-attachments/assets/17709968-94e9-4c03-85fc-e48fc2835768" />


---

## ⚠️ 기타 사항
- 마크다운 파싱은 \n\n 기준으로 구분
