### PR TITLE
Fix: 스크랩-그룹-종목셀렉터로 카드 안넘어가는 문제 수정

### DIFF
--- a/src/components/scrap/ScrapStockSelector.tsx
+++ b/src/components/scrap/ScrapStockSelector.tsx
@@ -60,9 +60,6 @@ export const ScrapStockSelector = ({
 
   // 좌/우 버튼 클릭 시 이전/다음 스냅샷을 선택하는 함수
   const changeStock = (direction: "left" | "right") => {
-    // 종목별 카드일 때만 카드 넘기기 허용
-    if (!isStockDetail) return;
-    
     if (!snapshots || snapshots.length === 0) return;
 
     let newIndex = currentIndex + (direction === "left" ? -1 : 1);


### PR DESCRIPTION
## 🔀 PR 개요
- 어떤 작업을 했는지 한 문장으로 요약해주세요.
스크랩-그룹-종목셀렉터로 카드 안넘어가는 문제 수정
---

## ✅ 작업 내용
- 주요 변경사항 리스트
- 어떤 기능이 추가/변경/삭제되었는지 명확하게 작성
스크랩-그룹-종목셀렉터로 카드 안넘어가는 문제 수정
---

## 📌 관련 이슈
- Close #이슈번호 (자동으로 연결되도록)

---

## 📸 스크린샷 (선택)
- UI 변경이 있을 경우 첨부해주세요.

---

## ⚠️ 기타 사항
- 리뷰 전에 알리고 싶은 내용이 있다면 적어주세요.
